### PR TITLE
BUG: pvconst is not a singleton, inconsistent, doesn't update (GH38)

### DIFF
--- a/pvmismatch/pvmismatch_lib/pvcell.py
+++ b/pvmismatch/pvmismatch_lib/pvcell.py
@@ -105,7 +105,7 @@ class PVcell(object):
         self._calc_now = False
         for k, v in iteritems(kwargs):
             setattr(self, k, v)
-        self._calc_now = False  # recalculate
+        self._calc_now = True  # recalculate
 
     @property
     def Vt(self):

--- a/pvmismatch/pvmismatch_lib/pvcell.py
+++ b/pvmismatch/pvmismatch_lib/pvcell.py
@@ -47,6 +47,9 @@ class PVcell(object):
     :param pvconst: configuration constants object
     :type pvconst: :class:`~pvmismatch.pvmismatch_lib.pvconstants.PVconstants`
     """
+
+    _calc_now = False  #: if True ``calcCells()`` is called in ``__setattr__``
+
     def __init__(self, Rs=RS, Rsh=RSH, Isat1_T0=ISAT1_T0, Isat2=ISAT2,
                  Isc0_T0=ISC0_T0, aRBD=ARBD, bRBD=BRBD, VRBD=VRBD_,
                  nRBD=NRBD, Eg=EG, alpha_Isc=ALPHA_ISC,
@@ -69,6 +72,8 @@ class PVcell(object):
         self.Icell = None  #: cell currents on IV curve [A]
         self.Vcell = None  #: cell voltages on IV curve [V]
         self.Pcell = None  #: cell power on IV curve [W]
+        # set calculation flag
+        self._calc_now = True  # overwrites the class attribute
 
     def __str__(self):
         fmt = '<PVcell(Ee=%g[suns], Tcell=%g[K], Isc=%g[A], Voc=%g[V])>'
@@ -78,27 +83,29 @@ class PVcell(object):
         return str(self)
 
     def __setattr__(self, key, value):
+        # check for floats
         try:
             value = np.float64(value)
         except (TypeError, ValueError):
-            pass
+            pass  # fail silently if not float, eg: pvconst or _calc_now
         super(PVcell, self).__setattr__(key, value)
-        # after all attributes have been initialized, recalculate IV curve
-        # every time __setattr__() is called
-        if hasattr(self, 'pvconst'):
+        # recalculate IV curve
+        if self._calc_now:
             Icell, Vcell, Pcell = self.calcCell()
-            super(PVcell, self).__setattr__('Icell', Icell)
-            super(PVcell, self).__setattr__('Vcell', Vcell)
-            super(PVcell, self).__setattr__('Pcell', Pcell)
+            # super(PVcell, self).__setattr__('Icell', Icell)
+            # super(PVcell, self).__setattr__('Vcell', Vcell)
+            # super(PVcell, self).__setattr__('Pcell', Pcell)
+            self.__dict__.update(Icell=Icell, Vcell=Vcell, Pcell=Pcell)
 
     def update(self, **kwargs):
         """
         Update user-defined constants.
         """
-        # TODO: use __dict__.update(), check for floats and update IV curve
-        # self.__dict__.update(kwargs)
+        # turn off calculation flag until all attributes are updated
+        self._calc_now = False
         for k, v in iteritems(kwargs):
             setattr(self, k, v)
+        self._calc_now = False  # recalculate
 
     @property
     def Vt(self):

--- a/pvmismatch/pvmismatch_lib/pvcell.py
+++ b/pvmismatch/pvmismatch_lib/pvcell.py
@@ -92,9 +92,6 @@ class PVcell(object):
         # recalculate IV curve
         if self._calc_now:
             Icell, Vcell, Pcell = self.calcCell()
-            # super(PVcell, self).__setattr__('Icell', Icell)
-            # super(PVcell, self).__setattr__('Vcell', Vcell)
-            # super(PVcell, self).__setattr__('Pcell', Pcell)
             self.__dict__.update(Icell=Icell, Vcell=Vcell, Pcell=Pcell)
 
     def update(self, **kwargs):
@@ -103,6 +100,8 @@ class PVcell(object):
         """
         # turn off calculation flag until all attributes are updated
         self._calc_now = False
+        # don't use __dict__.update() instead use setattr() to go through
+        # custom __setattr__() so that numbers are cast to floats
         for k, v in iteritems(kwargs):
             setattr(self, k, v)
         self._calc_now = True  # recalculate

--- a/pvmismatch/pvmismatch_lib/pvconstants.py
+++ b/pvmismatch/pvmismatch_lib/pvconstants.py
@@ -74,23 +74,39 @@ class PVconstants(object):
     T0 = 298.15  #: [K] reference temperature
 
     def __init__(self, npts=NPTS):
-        # set number of points in IV curve(s)
-        self.npts = npts  #: number of points in IV curves
-        # point spacing from 0 to 1, used for Vcell, Vmod, Vsys and Istring
-        # decrease point spacing as voltage approaches Voc by using logspace
-        pts = (11. - np.logspace(np.log10(11.), 0., self.npts)) / 10.
-        pts[0] = 0.  # first point must be exactly zero
-        self.pts = pts.reshape((self.npts, 1))
+        self._npts = None
+        self.pts = None
         """array of points with decreasing spacing from 0 to 1"""
-        negpts = (11. - np.logspace(np.log10(11. - 1. / float(self.npts)),
-                                    0., self.npts)) / 10.
-        negpts = negpts.reshape((self.npts, 1))
-        self.Imod_negpts = 1 + 1. / float(self.npts) / 10. - negpts
+        self.Imod_negpts = None
         """array of points with decreasing spacing from 1 to just less than but
         not including zero"""
-        self.negpts = np.flipud(negpts)  # reverse the order
+        self.negpts = None
         """array of points with increasing spacing from 1 to just less than but
         not including zero"""
+        self.Imod_pts = None
+        """array of points with increasing spacing from 0 to 1"""
+        # call property setter
+        self.npts = npts  #: number of points in IV curves
+
+    @property
+    def npts(self):
+        """number of points in IV curves"""
+        return self._npts
+
+    @npts.setter
+    def npts(self, npts):
+        # set number of points in IV curve(s)
+        self._npts = npts  # number of points in IV curves
+        # point spacing from 0 to 1, used for Vcell, Vmod, Vsys and Istring
+        # decrease point spacing as voltage approaches Voc by using logspace
+        pts = (11. - np.logspace(np.log10(11.), 0., self._npts)) / 10.
+        pts[0] = 0.  # first point must be exactly zero
+        self.pts = pts.reshape((self._npts, 1))
+        negpts = (11. - np.logspace(np.log10(11. - 1. / float(self._npts)),
+                                    0., self._npts)) / 10.
+        negpts = negpts.reshape((self._npts, 1))
+        self.Imod_negpts = 1 + 1. / float(self._npts) / 10. - negpts
+        self.negpts = np.flipud(negpts)  # reverse the order
         # shift and concatenate pvconst.negpts and pvconst.pts
         # so that tight spacing is around MPP and RBD
         self.Imod_pts = 1 - np.flipud(self.pts)

--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -57,6 +57,7 @@ def standard_cellpos_pat(nrows, ncols_per_substr):
         cellpos.append(newsubstr)
     return cellpos
 
+
 # standard cell positions presets
 STD24 = standard_cellpos_pat(1, [1] * 24)
 STD72 = standard_cellpos_pat(12, [2, 2, 2])
@@ -122,6 +123,7 @@ Standard Tiled module with partial cross-ties: 82x6 cells
 Substrings have 27, 28 and 27 rows of cells per diode
 """
 
+
 def combine_parallel_circuits(IVprev_cols, pvconst):
     """
     Combine crosstied circuits in a substring
@@ -151,6 +153,7 @@ def combine_parallel_circuits(IVprev_cols, pvconst):
         Irows, Vrows, Isc_rows.mean(), Imax_rows.max()
     )
 
+
 class PVmodule(object):
     """
     A Class for PV modules.
@@ -158,26 +161,42 @@ class PVmodule(object):
     :param cell_pos: cell position pattern
     :type cell_pos: dict
     :param pvcells: list of :class:`~pvmismatch.pvmismatch_lib.pvcell.PVcell`
-    :type pvcells: list
+    :type pvcells: list, :class:`~pvmismatch.pvmismatch_lib.pvcell.PVcell`
     :param pvconst: An object with common parameters and constants.
     :type pvconst: :class:`~pvmismatch.pvmismatch_lib.pvconstants.PVconstants`
     :param Vbypass: bypass diode trigger voltage [V]
     :param cellArea: cell area [cm^2]
     """
-    def __init__(self, cell_pos=STD96, pvcells=None, pvconst=PVconstants(),
+    def __init__(self, cell_pos=STD96, pvcells=None, pvconst=None,
                  Vbypass=VBYPASS, cellArea=CELLAREA):
         # TODO: check cell position pattern
         self.cell_pos = cell_pos  #: cell position pattern dictionary
         self.numberCells = sum([len(c) for s in self.cell_pos for c in s])
         """number of cells in the module"""
+        # is pvcells a list?
+        try:
+            pvc0 = pvcells[0]
+        except TypeError:
+            # is pvcells an object?
+            try:
+                pvconst = pvcells.pvconst
+            except AttributeError:
+                #  try to use the pvconst arg or create one if none
+                if not pvconst:
+                    pvconst = PVconstants()
+                # create pvcell
+                pvcells = PVcell(pvconst=pvconst)
+            # expand pvcells to list
+            pvcells = [pvcells] * self.numberCells
+        else:
+            pvconst = pvc0.pvconst
+            for p in pvcells:
+                if p.pvconst is not pvconst:
+                    raise Exception('PVconstant must be the same for all cells')
         self.pvconst = pvconst  #: configuration constants
         self.Vbypass = Vbypass  #: [V] trigger voltage of bypass diode
         self.cellArea = cellArea  #: [cm^2] cell area
-        if pvcells is None:
-            pvcells = PVcell(pvconst=self.pvconst)
-        # expand pvcells to list
-        if isinstance(pvcells, PVcell):
-            pvcells = [pvcells] * self.numberCells
+        # check cell position pattern matches list of cells
         if len(pvcells) != self.numberCells:
             # TODO: use pvexception
             raise Exception(
@@ -291,8 +310,10 @@ class PVmodule(object):
                 raise Exception("Input irradiance value (Ee) for each cell!")
         self.Imod, self.Vmod, self.Pmod, self.Isubstr, self.Vsubstr = self.calcMod()
 
-# TODO setTemps is a nearly identical copy of setSuns. The DRY principle says that we should not be copying code.
-# TODO Replace both setSuns() and setTemps() with a single method for updating cell parameters that works for all params
+    # TODO setTemps is a nearly identical copy of setSuns. The DRY principle
+    # says that we should not be copying code.
+    # TODO Replace both setSuns() and setTemps() with a single method for
+    # updating cell parameters that works for all params
 
     def setTemps(self, Tc, cells=None):
         """

--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -174,10 +174,8 @@ class PVmodule(object):
         self.Vbypass = Vbypass  #: [V] trigger voltage of bypass diode
         self.cellArea = cellArea  #: [cm^2] cell area
         if pvcells is None:
-            # faster to use copy instead of making each object in a for-loop
-            # use copy instead of deepcopy to keep same pvconst for all objects
-            # PVcell.calcCell() creates new np.ndarray if attributes change
             pvcells = PVcell(pvconst=self.pvconst)
+        # expand pvcells to list
         if isinstance(pvcells, PVcell):
             pvcells = [pvcells] * self.numberCells
         if len(pvcells) != self.numberCells:

--- a/pvmismatch/pvmismatch_lib/pvstring.py
+++ b/pvmismatch/pvmismatch_lib/pvstring.py
@@ -30,18 +30,21 @@ class PVstring(object):
         self.pvconst = pvconst
         self.numberMods = numberMods
         if pvmods is None:
-            # use deepcopy instead of making each object in for-loop, 2x faster
             pvmods = PVmodule(pvconst=self.pvconst)
+        # expand pvmods to list
         if isinstance(pvmods, PVmodule):
             pvmods = [pvmods] * self.numberMods
-            # reset pvconsts in all pvcells and pvmodules
-            for p in pvmods:
-                for c in p.pvcells:
-                    c.pvconst = self.pvconst
-                p.pvconst = self.pvconst
         if len(pvmods) != self.numberMods:
             # TODO: use pvmismatch exceptions
             raise Exception("Number of modules doesn't match.")
+        # check that pvconst if given, is the same for all cells
+        # don't assign pvcell.pvconst here since it triggers a recalc
+        for p in pvmods:
+            for c in p.pvcells:
+                if c.pvconst is not self.pvconst:
+                    raise Exception('PVconstant must be the same for all cells')
+            if p.pvconst is not self.pvconst:
+                raise Exception('PVconstant must be the same for all cells')
         self.pvmods = pvmods
         self.Istring, self.Vstring, self.Pstring = self.calcString()
 

--- a/pvmismatch/pvmismatch_lib/pvstring.py
+++ b/pvmismatch/pvmismatch_lib/pvstring.py
@@ -47,7 +47,7 @@ class PVstring(object):
             numberMods = len(pvmods)
             for p in pvmods:
                 if p.pvconst is not pvconst:
-                    raise Exception('PVconstant must be the same for all cells')
+                    raise Exception('pvconst must be the same for all modules')
         self.pvconst = pvconst  #: ``PVconstants`` used in  ``PVstring``
         self.numberMods = numberMods  #: number of module in string
         self.pvmods = pvmods  #: list of ``PVModule`` in ``PVstring``

--- a/pvmismatch/pvmismatch_lib/pvstring.py
+++ b/pvmismatch/pvmismatch_lib/pvstring.py
@@ -26,26 +26,32 @@ class PVstring(object):
     :param pvconst: a configuration constants object
     """
     def __init__(self, numberMods=NUMBERMODS, pvmods=None,
-                 pvconst=PVconstants()):
-        self.pvconst = pvconst
-        self.numberMods = numberMods
-        if pvmods is None:
-            pvmods = PVmodule(pvconst=self.pvconst)
-        # expand pvmods to list
-        if isinstance(pvmods, PVmodule):
-            pvmods = [pvmods] * self.numberMods
-        if len(pvmods) != self.numberMods:
-            # TODO: use pvmismatch exceptions
-            raise Exception("Number of modules doesn't match.")
-        # check that pvconst if given, is the same for all cells
-        # don't assign pvcell.pvconst here since it triggers a recalc
-        for p in pvmods:
-            for c in p.pvcells:
-                if c.pvconst is not self.pvconst:
+                 pvconst=None):
+        # is pvmods a list?
+        try:
+            pvmod0 = pvmods[0]
+        except TypeError:
+            # is pvmods an object?
+            try:
+                pvconst = pvmods.pvcons
+            except AttributeError:
+                #  try to use the pvconst arg or create one if none
+                if not pvconst:
+                    pvconst = PVconstants()
+                # create pvmod
+                pvmods = PVmodule(pvconst=pvconst)
+            # expand pvmods to list
+            pvmods = [pvmods] * numberMods
+        else:
+            pvconst = pvmod0.pvconst
+            numberMods = len(pvmods)
+            for p in pvmods:
+                if p.pvconst is not pvconst:
                     raise Exception('PVconstant must be the same for all cells')
-            if p.pvconst is not self.pvconst:
-                raise Exception('PVconstant must be the same for all cells')
-        self.pvmods = pvmods
+        self.pvconst = pvconst  #: ``PVconstants`` used in  ``PVstring``
+        self.numberMods = numberMods  #: number of module in string
+        self.pvmods = pvmods  #: list of ``PVModule`` in ``PVstring``
+        # calculate string
         self.Istring, self.Vstring, self.Pstring = self.calcString()
 
     # TODO: use __getattr__ to check for updates to pvcells

--- a/pvmismatch/pvmismatch_lib/pvsystem.py
+++ b/pvmismatch/pvmismatch_lib/pvsystem.py
@@ -45,20 +45,20 @@ class PVsystem(object):
                                   pvconst=pvconst)
             # expand pvstrs to list
             pvstrs = [pvstrs] * numberStrs
+            numberMods = [numberMods] * numberStrs
         else:
             pvconst = pvstr0.pvconst
             numberStrs = len(pvstrs)
-            numberMods = len(pvstr0.pvmods)
+            numberMods = []
             for p in pvstrs:
                 if p.pvconst is not pvconst:
                     raise Exception('pvconst must be the same for all strings')
-                if len(p.pvmods) != numberMods:
-                    raise Exception('pvmods must be the same for all strings')
-        self.pvconst = pvconst
-        self.numberStrs = numberStrs
-        self.numberMods = numberMods
-        self.pvstrs = pvstrs
-        # calculate pv system
+                numberMods.append(len(p.pvmods))
+        self.pvconst = pvconst  #: ``PVconstants`` used in ``PVsystem``
+        self.numberStrs = numberStrs  #: number strings in the system
+        self.numberMods = numberMods  #: list of number of modules per string
+        self.pvstrs = pvstrs  #: list of ``PVstring`` in system
+        # calculate pvsystem
         self.Isys, self.Vsys, self.Psys = self.calcSystem()
         (self.Imp, self.Vmp, self.Pmp,
          self.Isc, self.Voc, self.FF, self.eff) = self.calcMPP_IscVocFFeff()

--- a/pvmismatch/pvmismatch_lib/pvsystem.py
+++ b/pvmismatch/pvmismatch_lib/pvsystem.py
@@ -59,6 +59,10 @@ class PVsystem(object):
         self.numberMods = numberMods  #: list of number of modules per string
         self.pvstrs = pvstrs  #: list of ``PVstring`` in system
         # calculate pvsystem
+        self.update()
+
+    def update(self):
+        """Update system calculations."""
         self.Isys, self.Vsys, self.Psys = self.calcSystem()
         (self.Imp, self.Vmp, self.Pmp,
          self.Isc, self.Voc, self.FF, self.eff) = self.calcMPP_IscVocFFeff()
@@ -141,9 +145,8 @@ class PVsystem(object):
                 pvstr = int(pvstr)
                 self.pvstrs[pvstr] = copy(self.pvstrs[pvstr])
                 self.pvstrs[pvstr].setSuns(pvmod_Ee)
-        self.Isys, self.Vsys, self.Psys = self.calcSystem()
-        (self.Imp, self.Vmp, self.Pmp,
-         self.Isc, self.Voc, self.FF, self.eff) = self.calcMPP_IscVocFFeff()
+        # calculate pvsystem
+        self.update()
 
     def setTemps(self, Tc):
         """
@@ -179,9 +182,8 @@ class PVsystem(object):
                 pvstr = int(pvstr)
                 self.pvstrs[pvstr] = copy(self.pvstrs[pvstr])
                 self.pvstrs[pvstr].setTemps(pvmod_Tc)
-        self.Isys, self.Vsys, self.Psys = self.calcSystem()
-        (self.Imp, self.Vmp, self.Pmp,
-         self.Isc, self.Voc, self.FF, self.eff) = self.calcMPP_IscVocFFeff()
+        # calculate pvsystem
+        self.update()
 
     def plotSys(self, sysPlot=None):
         """

--- a/pvmismatch/pvmismatch_lib/pvsystem.py
+++ b/pvmismatch/pvmismatch_lib/pvsystem.py
@@ -35,7 +35,7 @@ class PVsystem(object):
         if pvstrs is None:
             pvstrs = PVstring(numberMods=self.numberMods, pvmods=pvmods,
                               pvconst=self.pvconst)
-        # use deep copy instead of making each object in a for-loop
+        # expand pvstrs to list
         if isinstance(pvstrs, PVstring):
             pvstrs = [pvstrs] * self.numberStrs
         if len(pvstrs) != self.numberStrs:

--- a/pvmismatch/tests/test_pvcell.py
+++ b/pvmismatch/tests/test_pvcell.py
@@ -69,6 +69,21 @@ def test_pvcell_calc_rbd():
     pvc2 = PVcell(bRBD=-0.056)
     ok_(isinstance(pvc2, PVcell))
 
-        
+
+def test_pvcell_calc_now_flag():
+    pvc = PVcell()
+    itest, vtest, ptest = pvc.Icell, pvc.Vcell, pvc.Pcell
+    pvc._calc_now = False
+    pvc.Rs = 0.001
+    assert np.allclose(itest, pvc.Icell)
+    assert np.allclose(vtest, pvc.Vcell)
+    assert np.allclose(ptest, pvc.Pcell)
+    icell, vcell, pcell = pvc.calcCell()
+    pvc._calc_now = True
+    assert np.allclose(icell, pvc.Icell)
+    assert np.allclose(vcell, pvc.Vcell)
+    assert np.allclose(pcell, pvc.Pcell)
+
+
 if __name__ == "__main__":
     test_calc_series()

--- a/pvmismatch/tests/test_pvcell.py
+++ b/pvmismatch/tests/test_pvcell.py
@@ -71,6 +71,9 @@ def test_pvcell_calc_rbd():
 
 
 def test_pvcell_calc_now_flag():
+    """
+    Test ``_calc_now`` turns off recalc in ``__setattr__``.
+    """
     pvc = PVcell()
     itest, vtest, ptest = pvc.Icell, pvc.Vcell, pvc.Pcell
     pvc._calc_now = False
@@ -83,6 +86,19 @@ def test_pvcell_calc_now_flag():
     assert np.allclose(icell, pvc.Icell)
     assert np.allclose(vcell, pvc.Vcell)
     assert np.allclose(pcell, pvc.Pcell)
+
+
+def test_update():
+    pvc = PVcell()
+    Rs = pvc.Rs
+    itest = pvc.Icell[170]
+    pvc.update(Rs=0.001)
+    assert np.isclose(pvc.Icell[170], 5.79691674)
+    pvc._calc_now = False
+    pvc.Rs = Rs
+    pvc.update()  # resets _calc_now to True
+    assert np.isclose(pvc.Icell[170], itest)
+    assert pvc._calc_now
 
 
 if __name__ == "__main__":

--- a/pvmismatch/tests/test_pvconstants.py
+++ b/pvmismatch/tests/test_pvconstants.py
@@ -1,0 +1,21 @@
+from pvmismatch import *
+
+
+def test_pvconst_npts_setter():
+    """Test pvconst property and setter methods"""
+    pvconst = pvconstants.PVconstants()
+    assert pvconst.npts == pvconstants.NPTS
+    assert len(pvconst.pts) == pvconst.npts
+    assert pvconst.pts[0] == 0
+    assert pvconst.pts[-1] == 1
+    assert len(pvconst.negpts) == pvconst.npts
+    assert pvconst.negpts[0] == 1
+    assert pvconst.negpts[-1] > 0
+    pvconst.npts = 1001
+    assert pvconst.npts == 1001
+    assert len(pvconst.pts) == pvconst.npts
+    assert pvconst.pts[0] == 0
+    assert pvconst.pts[-1] == 1
+    assert len(pvconst.negpts) == pvconst.npts
+    assert pvconst.negpts[0] == 1
+    assert pvconst.negpts[-1] > 0

--- a/pvmismatch/tests/test_pvmodule.py
+++ b/pvmismatch/tests/test_pvmodule.py
@@ -4,6 +4,7 @@ Tests for pvmodules.
 
 from nose.tools import ok_
 from pvmismatch.pvmismatch_lib.pvmodule import PVmodule, TCT492, PCT492
+from pvmismatch.pvmismatch_lib.pvcell import PVcell
 import numpy as np
 from copy import copy
 
@@ -39,6 +40,30 @@ def test_calc_pct_bridges():
     pct492_bridges[0][4][2]['crosstie'] = True
     pvmod = PVmodule(cell_pos=pct492_bridges)
     return pvmod
+
+
+def check_same_pvconst_and_lengths(pvmod):
+    assert len(pvmod.pvcells) == 96
+    for p in pvmod.pvcells:
+        assert p.pvconst is pvmod.pvconst
+
+
+def test_pvmodule_with_pvcells_list():
+    pvcells = [PVcell()] * 96
+    pvmod = PVmodule(pvcells=pvcells)
+    check_same_pvconst_and_lengths(pvmod)
+
+
+def test_pvmodule_with_pvcells_obj():
+    pvcells = PVcell()
+    pvmod = PVmodule(pvcells=pvcells)
+    check_same_pvconst_and_lengths(pvmod)
+
+
+def test_pvmodule_with_no_pvcells():
+    pvmod = PVmodule()
+    check_same_pvconst_and_lengths(pvmod)
+
 
 if __name__ == "__main__":
     test_calc_mod()

--- a/pvmismatch/tests/test_pvstring.py
+++ b/pvmismatch/tests/test_pvstring.py
@@ -1,7 +1,6 @@
 from pvmismatch import *
 
 
-
 def check_same_pvconst_and_lengths(pvstr):
     assert len(pvstr.pvmods) == pvstring.NUMBERMODS
     for p in pvstr.pvmods:

--- a/pvmismatch/tests/test_pvstring.py
+++ b/pvmismatch/tests/test_pvstring.py
@@ -1,0 +1,25 @@
+from pvmismatch import *
+
+
+
+def check_same_pvconst_and_lengths(pvstr):
+    assert len(pvstr.pvmods) == pvstring.NUMBERMODS
+    for p in pvstr.pvmods:
+        assert p.pvconst is pvstr.pvconst
+
+
+def test_pvstring_with_pvmods_list():
+    pvmods = [pvmodule.PVmodule()] * pvstring.NUMBERMODS
+    pvstr = pvstring.PVstring(pvmods=pvmods)
+    check_same_pvconst_and_lengths(pvstr)
+
+
+def test_pvstring_with_pvmods_obj():
+    pvmods = pvmodule.PVmodule()
+    pvstr = pvstring.PVstring(pvmods=pvmods)
+    check_same_pvconst_and_lengths(pvstr)
+
+
+def test_pvstring_with_no_pvmods():
+    pvstr = pvstring.PVstring()
+    check_same_pvconst_and_lengths(pvstr)

--- a/pvmismatch/tests/test_pvsystem.py
+++ b/pvmismatch/tests/test_pvsystem.py
@@ -5,7 +5,6 @@ def check_same_pvconst_and_lengths(pvsys):
     assert len(pvsys.pvstrs) == pvsystem.NUMBERSTRS
     for p in pvsys.pvstrs:
         assert p.pvconst is pvsys.pvconst
-        assert len(p.pvmods) == pvsystem.NUMBERMODS
 
 
 def test_pvsystem_with_pvstrs_list():

--- a/pvmismatch/tests/test_pvsystem.py
+++ b/pvmismatch/tests/test_pvsystem.py
@@ -1,0 +1,25 @@
+from pvmismatch import *
+
+
+def check_same_pvconst_and_lengths(pvsys):
+    assert len(pvsys.pvstrs) == pvsystem.NUMBERSTRS
+    for p in pvsys.pvstrs:
+        assert p.pvconst is pvsys.pvconst
+        assert len(p.pvmods) == pvsystem.NUMBERMODS
+
+
+def test_pvsystem_with_pvstrs_list():
+    pvstrs = [pvstring.PVstring()] * pvsystem.NUMBERSTRS
+    pvsys = pvsystem.PVsystem(pvstrs=pvstrs)
+    check_same_pvconst_and_lengths(pvsys)
+
+
+def test_pvsystem_with_pvstrs_obj():
+    pvstrs = pvstring.PVstring()
+    pvsys = pvsystem.PVsystem(pvstrs=pvstrs)
+    check_same_pvconst_and_lengths(pvsys)
+
+
+def test_pvsystem_with_no_pvstrs():
+    pvsys = pvsystem.PVsystem()
+    check_same_pvconst_and_lengths(pvsys)

--- a/pvmismatch/tests/test_pvsystem.py
+++ b/pvmismatch/tests/test_pvsystem.py
@@ -3,8 +3,9 @@ from pvmismatch import *
 
 def check_same_pvconst_and_lengths(pvsys):
     assert len(pvsys.pvstrs) == pvsystem.NUMBERSTRS
-    for p in pvsys.pvstrs:
+    for n, p in enumerate(pvsys.pvstrs):
         assert p.pvconst is pvsys.pvconst
+        assert len(p.pvmods) == pvsys.numberMods[n]
 
 
 def test_pvsystem_with_pvstrs_list():


### PR DESCRIPTION
fixes #38 

* use ducktyping instead of instance check to see if arg is list, obj, or none
* don't set an argument default with a constructor, instead use None
* make sure that the same `pvconst` is used throughout the next lower level, cascading down from `pvsystem` to `pvstring` to `pvmodule` to `pvcell`, otherwise weird things can happen