### PR TITLE
Fix mpp temperature sensitivity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ deploy:
     on:
       tags: true
   - provider: pypi
-    user: bwanamarko
+    user: perfspwr
     password: $PYPI_PASSWORD
     distributions: "sdist bdist_wheel" # Your distributions here
     skip_upload_docs: true

--- a/pvmismatch/pvmismatch_lib/pvsystem.py
+++ b/pvmismatch/pvmismatch_lib/pvsystem.py
@@ -94,26 +94,21 @@ class PVsystem(object):
 
     def calcMPP_IscVocFFeff(self):
         mpp = np.argmax(self.Psys)
-
         P = self.Psys[mpp - 1:mpp + 2]
         V = self.Vsys[mpp - 1:mpp + 2]
         I = self.Isys[mpp - 1:mpp + 2]
-
         # calculate derivative dP/dV using central difference
         dP = np.diff(P, axis=0)  # size is (2, 1)
         dV = np.diff(V, axis=0)  # size is (2, 1)
         Pv = dP / dV  # size is (2, 1)
-
         # dP/dV is central difference at midpoints,
         Vmid = (V[1:] + V[:-1]) / 2.0  # size is (2, 1)
         Imid = (I[1:] + I[:-1]) / 2.0  # size is (2, 1)
-
         # interpolate to find Vmp
         Vmp = -Pv[0] * np.diff(Vmid, axis=0) / np.diff(Pv, axis=0) + Vmid[0]
         Imp = -Pv[0] * np.diff(Imid, axis=0) / np.diff(Pv, axis=0) + Imid[0]
         # calculate max power at Pv = 0
         Pmp = Imp * Vmp
-        
         # calculate Voc, current must be increasing so flipup()
         Voc = np.interp(np.float64(0), np.flipud(self.Isys),
                         np.flipud(self.Vsys))

--- a/pvmismatch/pvmismatch_lib/pvsystem.py
+++ b/pvmismatch/pvmismatch_lib/pvsystem.py
@@ -94,9 +94,26 @@ class PVsystem(object):
 
     def calcMPP_IscVocFFeff(self):
         mpp = np.argmax(self.Psys)
-        Pmp = self.Psys[mpp]
-        Vmp = self.Vsys[mpp]
-        Imp = self.Isys[mpp]
+
+        P = self.Psys[mpp - 1:mpp + 2, 0]
+        V = self.Vsys[mpp - 1:mpp + 2, 0]
+        I = self.Isys[mpp - 1:mpp + 2, 0]
+
+        # calculate derivative dP/dV using central difference
+        dP = np.diff(P, axis=0)  # size is (2, 1)
+        dV = np.diff(V, axis=0)  # size is (2, 1)
+        Pv = dP / dV  # size is (2, 1)
+
+        # dP/dV is central difference at midpoints,
+        Vmid = (V[1:] + V[:-1]) / 2.0  # size is (2, 1)
+        Imid = (I[1:] + I[:-1]) / 2.0  # size is (2, 1)
+
+        # interpolate to find Vmp
+        Vmp = -Pv[0] * np.diff(Vmid, axis=0) / np.diff(Pv, axis=0) + Vmid[0]
+        Imp = -Pv[0] * np.diff(Imid, axis=0) / np.diff(Pv, axis=0) + Imid[0]
+        # calculate max power at Pv = 0
+        Pmp = Imp * Vmp
+        
         # calculate Voc, current must be increasing so flipup()
         Voc = np.interp(np.float64(0), np.flipud(self.Isys),
                         np.flipud(self.Vsys))

--- a/pvmismatch/pvmismatch_lib/pvsystem.py
+++ b/pvmismatch/pvmismatch_lib/pvsystem.py
@@ -95,9 +95,9 @@ class PVsystem(object):
     def calcMPP_IscVocFFeff(self):
         mpp = np.argmax(self.Psys)
 
-        P = self.Psys[mpp - 1:mpp + 2, 0]
-        V = self.Vsys[mpp - 1:mpp + 2, 0]
-        I = self.Isys[mpp - 1:mpp + 2, 0]
+        P = self.Psys[mpp - 1:mpp + 2]
+        V = self.Vsys[mpp - 1:mpp + 2]
+        I = self.Isys[mpp - 1:mpp + 2]
 
         # calculate derivative dP/dV using central difference
         dP = np.diff(P, axis=0)  # size is (2, 1)

--- a/pvmismatch/pvmismatch_lib/pvsystem.py
+++ b/pvmismatch/pvmismatch_lib/pvsystem.py
@@ -105,8 +105,8 @@ class PVsystem(object):
         Vmid = (V[1:] + V[:-1]) / 2.0  # size is (2, 1)
         Imid = (I[1:] + I[:-1]) / 2.0  # size is (2, 1)
         # interpolate to find Vmp
-        Vmp = -Pv[0] * np.diff(Vmid, axis=0) / np.diff(Pv, axis=0) + Vmid[0]
-        Imp = -Pv[0] * np.diff(Imid, axis=0) / np.diff(Pv, axis=0) + Imid[0]
+        Vmp = (-Pv[0] * np.diff(Vmid, axis=0) / np.diff(Pv, axis=0) + Vmid[0]).item()
+        Imp = (-Pv[0] * np.diff(Imid, axis=0) / np.diff(Pv, axis=0) + Imid[0]).item()
         # calculate max power at Pv = 0
         Pmp = Imp * Vmp
         # calculate Voc, current must be increasing so flipup()

--- a/pvmismatch/tests/test_setsuns.py
+++ b/pvmismatch/tests/test_setsuns.py
@@ -16,42 +16,45 @@ LOGGER = logging.getLogger(__name__)
 def test_basic():
     pvsys = PVsystem()
     pvsys.setSuns(.75)
-    ok_(np.isclose(pvsys.Pmp, 23907.936630685774))
+    ok_(np.isclose(pvsys.Pmp, 23903.15106763))
 
 
 def test_dictionary():
     pvsys = PVsystem()
     Ee = {1: {3: {'cells': np.arange(30), 'Ee': [.25] * 30}}}
     pvsys.setSuns(Ee)
-    ok_(np.isclose(pvsys.Pmp, 31618.1813179655))
+    ok_(np.isclose(pvsys.Pmp, 31610.21081155355))
 
 
 def test_set_mod_1():
     pvsys = PVsystem()
     Ee = {1: {3: [.2], 0: [.1]}}
     pvsys.setSuns(Ee)
-    ok_(np.isclose(pvsys.Pmp, 29566.303088387336))
+    ok_(np.isclose(pvsys.Pmp, 29559.422265401034))
 
 
 def test_set_mod_2():
     pvsys = PVsystem()
     Ee = {1: {3: .2, 0: .1}}
     pvsys.setSuns(Ee)
-    ok_(np.isclose(pvsys.Pmp, 29566.303088387336))
+    ok_(np.isclose(pvsys.Pmp, 29559.422265401034))
+    # 1001 points linear: [ 29579.12191565]
 
 
 def test_set_str_1():
     pvsys = PVsystem()
     Ee = {1: [.1]}
     pvsys.setSuns(Ee)
-    ok_(np.isclose(pvsys.Pmp, 29136.544447716446))
+    ok_(np.isclose(pvsys.Pmp, 29133.81083801798))
+    # 1001 points linear: [ 29141.73034719]
 
 
 def test_set_str_2():
     pvsys = PVsystem()
     Ee = {1: .1}
     pvsys.setSuns(Ee)
-    ok_(np.isclose(pvsys.Pmp, 29136.544447716446))
+    ok_(np.isclose(pvsys.Pmp, 29133.81083801798))
+    # 1001 points linear: [ 29141.73034719]
 
 
 def test_gh34_35():


### PR DESCRIPTION
Fixes I_mp and V_mp sensitivity to temperature caused by selecting Isys and Vsys values at the maximum Psys index. This is accomplished by linear interpolation between the points surrounding MPP.
Previously:
![i_mp_temp_old](https://user-images.githubusercontent.com/31972773/36693296-ba19e1f6-1aef-11e8-946f-21fe4c603a19.png)
Now:
![i_mp_temp_new](https://user-images.githubusercontent.com/31972773/36693316-c722586a-1aef-11e8-9318-ef5402be5eda.png)