### PR TITLE
Bypass diodes configurability

### DIFF
--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -508,8 +508,11 @@ class PVmodule(object):
                     Vbypass_mod = self.Vbypass[0]
                 # if more than 1 values are passed, apply them across  
                 # the cell strings in ascending order
-                elif len(self.cell_pos) == len(self.Vbypass):                    
-                    bypassed = Vsub < self.Vbypass[substr_idx]
+                elif len(self.cell_pos) == len(self.Vbypass):    
+                    if self.Vbypass[substr_idx] is None:
+                        bypassed = None
+                    else:
+                        bypassed = Vsub < self.Vbypass[substr_idx]
                     Vsub[bypassed] = self.Vbypass[substr_idx]
                 else:
                     raise Exception("wrong number of bypass diode values passed : %d"%(len(self.Vbypass)))

--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -516,6 +516,8 @@ class PVmodule(object):
                         Vsub[bypassed] = self.Vbypass[substr_idx]
                 else:
                     raise Exception("wrong number of bypass diode values passed : %d"%(len(self.Vbypass)))
+            elif self.Vbypass == 'None':
+                pass
             else:
                 # base case - Vbypass across every cell string
                 bypassed = Vsub < self.Vbypass

--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -496,8 +496,8 @@ class PVmodule(object):
                     bypassed = Vsub < self.Vbypass[substr_idx]
                     Vsub[bypassed] = self.Vbypass[substr_idx]
                 else:
-                    print("wrong number of bypass diodes passed : %d"%(len(self.Vbypass)))
-                    return None
+                    raise Exception("wrong number of bypass diodes passed : %d"%(len(self.Vbypass)))
+
             else:
                 bypassed = Vsub < self.Vbypass
                 Vsub[bypassed] = self.Vbypass

--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -537,35 +537,9 @@ class PVmodule(object):
                     bypassed = Vsub < self.Vbypass[substr_idx]
                     Vsub[bypassed] = self.Vbypass[substr_idx]
             elif self.Vbypass_config == 'module_bypass':
-                # bypass value will be assigned after the for loop for substrings is over
+                # module bypass value will be assigned after the for loop for substrings is over
                 pass
 
-            """
-            # apply bypass diodes depending on the configuration passed
-            try:
-                num_bypass = len(self.Vbypass)
-            except TypeError:
-                # base case - Vbypass across every cell string
-
-            else:
-                # if only one value is passed in the list- assume only one
-                # bypass diode  across the PV module
-                if len(self.Vbypass) == 1:
-                    bypass_entire_module = True
-                    Vbypass_mod = self.Vbypass[0]
-                # if more than 1 values are passed, apply them across
-                # the cell strings in ascending order
-                elif len(self.cell_pos) == num_bypass:
-                    if self.Vbypass[substr_idx] is None:
-                        # no bypass for this substring
-                        pass
-                    else:
-                        # bypass the substring
-                        bypassed = Vsub < self.Vbypass[substr_idx]
-                        Vsub[bypassed] = self.Vbypass[substr_idx]
-                else:
-                    raise PVexception("wrong number of bypass diode values passed : %d"%(len(self.Vbypass)))
-            """
             Isubstr.append(Isub)
             Vsubstr.append(Vsub)
             Isc_substr.append(np.interp(np.float64(0), Vsub, Isub))

--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -429,7 +429,6 @@ class PVmodule(object):
         """
         # iterate over substrings
         # TODO: benchmark speed difference append() vs preallocate space
-        bypass_entire_module = False
         Isubstr, Vsubstr, Isc_substr, Imax_substr = [], [], [], []
         for substr_idx, substr in enumerate(self.cell_pos):
             # check if cells are in series or any crosstied circuits

--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -513,7 +513,7 @@ class PVmodule(object):
                         bypassed = None
                     else:
                         bypassed = Vsub < self.Vbypass[substr_idx]
-                    Vsub[bypassed] = self.Vbypass[substr_idx]
+                        Vsub[bypassed] = self.Vbypass[substr_idx]
                 else:
                     raise Exception("wrong number of bypass diode values passed : %d"%(len(self.Vbypass)))
             else:

--- a/pvmismatch/tests/test_pvmodule.py
+++ b/pvmismatch/tests/test_pvmodule.py
@@ -64,6 +64,30 @@ def test_pvmodule_with_no_pvcells():
     pvmod = PVmodule()
     check_same_pvconst_and_lengths(pvmod)
 
+def test_bypass_diode_configurations():
+    # No bypass diodes
+    pvm = PVmodule(Vbypass = [None, None, None])
+    ok_(np.isclose(pvm.Vmod.min(), -530.6169665707829))
+        
+    # only one cell string has a bypass diode
+    pvm = PVmodule(Vbypass = [None, None,-0.5])
+    ok_(np.isclose(pvm.Vmod.min(), -398.46272492808714))
+    
+    # two bypass diodes (middle removed)
+    pvm = PVmodule(Vbypass = [-0.5, None,-0.5])
+    ok_(np.isclose(pvm.Vmod.min(), -266.30848328539145))
+
+    # all bypass diodes - same values
+    pvm = PVmodule(Vbypass = -0.2)
+    ok_(np.isclose(pvm.Vmod.min(), -0.6))
+
+    # one bypass diode across the module
+    pvm = PVmodule(Vbypass = [-0.7])
+    ok_(np.isclose(pvm.Vmod.min(), -0.7))
+
+    # default case    
+    pvm = PVmodule()
+    ok_(np.isclose(pvm.Vmod.min(), pvm.Vbypass * 3))
 
 if __name__ == "__main__":
     test_calc_mod()

--- a/pvmismatch/tests/test_pvmodule.py
+++ b/pvmismatch/tests/test_pvmodule.py
@@ -1,37 +1,32 @@
 """
 Tests for pvmodules.
 """
-
-from nose.tools import ok_
+import pytest
 from pvmismatch.pvmismatch_lib.pvmodule import PVmodule, TCT492, PCT492
 from pvmismatch.pvmismatch_lib.pvcell import PVcell
 import numpy as np
 from copy import copy
 
-
 def test_calc_mod():
     pvmod = PVmodule()
-    ok_(isinstance(pvmod, PVmodule))
+    assert (isinstance(pvmod, PVmodule))
     return pvmod
-
 
 def test_calc_tct_mod():
     pvmod = PVmodule(cell_pos=TCT492)
     isc = np.interp(np.float64(0), pvmod.Vmod, pvmod.Imod)
     voc = np.interp(np.float64(0), np.flipud(pvmod.Imod), np.flipud(pvmod.Vmod))
-    ok_(np.isclose(isc, 37.8335982026))
-    ok_(np.isclose(voc, 55.2798357318))
+    assert (np.isclose(isc, 37.8335982026))
+    assert (np.isclose(voc, 55.2798357318))
     return pvmod
-
 
 def test_calc_pct_mod():
     pvmod = PVmodule(cell_pos=PCT492)
     isc = np.interp(np.float64(0), pvmod.Vmod, pvmod.Imod)
     voc = np.interp(np.float64(0), np.flipud(pvmod.Imod), np.flipud(pvmod.Vmod))
-    ok_(np.isclose(isc, 37.8335982026))
-    ok_(np.isclose(voc, 55.2798357318))
+    assert (np.isclose(isc, 37.8335982026))
+    assert (np.isclose(voc, 55.2798357318))
     return pvmod
-
 
 def test_calc_pct_bridges():
     pct492_bridges = copy(PCT492)
@@ -41,24 +36,20 @@ def test_calc_pct_bridges():
     pvmod = PVmodule(cell_pos=pct492_bridges)
     return pvmod
 
-
 def check_same_pvconst_and_lengths(pvmod):
     assert len(pvmod.pvcells) == 96
     for p in pvmod.pvcells:
         assert p.pvconst is pvmod.pvconst
-
 
 def test_pvmodule_with_pvcells_list():
     pvcells = [PVcell()] * 96
     pvmod = PVmodule(pvcells=pvcells)
     check_same_pvconst_and_lengths(pvmod)
 
-
 def test_pvmodule_with_pvcells_obj():
     pvcells = PVcell()
     pvmod = PVmodule(pvcells=pvcells)
     check_same_pvconst_and_lengths(pvmod)
-
 
 def test_pvmodule_with_no_pvcells():
     pvmod = PVmodule()
@@ -67,27 +58,27 @@ def test_pvmodule_with_no_pvcells():
 def test_bypass_diode_configurations():
     # No bypass diodes
     pvm = PVmodule(Vbypass = [None, None, None])
-    ok_(np.isclose(pvm.Vmod.min(), -530.6169665707829))
+    assert (np.isclose(pvm.Vmod.min(), -530.6169665707829))
         
     # only one cell string has a bypass diode
     pvm = PVmodule(Vbypass = [None, None,-0.5])
-    ok_(np.isclose(pvm.Vmod.min(), -398.46272492808714))
+    assert (np.isclose(pvm.Vmod.min(), -398.46272492808714))
     
     # two bypass diodes (middle removed)
     pvm = PVmodule(Vbypass = [-0.5, None,-0.5])
-    ok_(np.isclose(pvm.Vmod.min(), -266.30848328539145))
+    assert (np.isclose(pvm.Vmod.min(), -266.30848328539145))
 
     # all bypass diodes - same values
     pvm = PVmodule(Vbypass = -0.2)
-    ok_(np.isclose(pvm.Vmod.min(), -0.6))
+    assert (np.isclose(pvm.Vmod.min(), -0.6))
 
     # one bypass diode across the module
     pvm = PVmodule(Vbypass = [-0.7])
-    ok_(np.isclose(pvm.Vmod.min(), -0.7))
+    assert (np.isclose(pvm.Vmod.min(), -0.7))
 
     # default case    
     pvm = PVmodule()
-    ok_(np.isclose(pvm.Vmod.min(), pvm.Vbypass * 3))
+    assert (np.isclose(pvm.Vmod.min(), pvm.Vbypass * 3))
 
 if __name__ == "__main__":
     test_calc_mod()


### PR DESCRIPTION
New feature to let the user model various scenarios with bypass diodes configurations.

    :param Vbypass: float|list of :float
        bypass diode trigger voltage [V]
        default case - one bypass diode per cell string (VBYPASS = -0.5V(V))
        float - one bypass diode per cell string with Vf = Vbypass (V)
        len(list) == 1 - one bypass diode per module (bypasses entire module )
        len(list) == len(cell_pos) - bypass diode value across cell string as 
                                     defined in the list

a code snippet to verify the various scenarios

```
import pvmismatch
from matplotlib import pyplot as plt
pvconstants = pvmismatch.pvmismatch_lib.pvconstants.PVconstants(npts=1001)

pvm = pvmismatch.pvmismatch_lib.pvmodule.PVmodule(Vbypass = [None, None, None])
plt.plot(pvm.Vmod, pvm.Imod, label ='No bypass diodes')


pvm = pvmismatch.pvmismatch_lib.pvmodule.PVmodule(Vbypass = [None, None,-0.5])
plt.plot(pvm.Vmod, pvm.Imod, label ='only one cell string has a bypass diode')

pvm = pvmismatch.pvmismatch_lib.pvmodule.PVmodule(Vbypass = [-0.5, None,-0.5])
plt.plot(pvm.Vmod, pvm.Imod, label ='two bypass diodes (middle removed)')

pvm = pvmismatch.pvmismatch_lib.pvmodule.PVmodule(Vbypass = -0.2)
plt.plot(pvm.Vmod, pvm.Imod, label ='all bypass diodes')

pvm = pvmismatch.pvmismatch_lib.pvmodule.PVmodule(Vbypass = [-0.5])
plt.plot(pvm.Vmod, pvm.Imod, label ='1 bypass diode across the module')

pvm = pvmismatch.pvmismatch_lib.pvmodule.PVmodule()
plt.plot(pvm.Vmod, pvm.Imod, label ='default')

plt.grid(True)
plt.xlabel('Voltage (V)')
plt.ylabel('Current (A)')

plt.legend()
```