### PR TITLE
[BUG] fix typo in pvstrings

### DIFF
--- a/pvmismatch/pvmismatch_lib/pvstring.py
+++ b/pvmismatch/pvmismatch_lib/pvstring.py
@@ -33,7 +33,7 @@ class PVstring(object):
         except TypeError:
             # is pvmods an object?
             try:
-                pvconst = pvmods.pvcons
+                pvconst = pvmods.pvconst
             except AttributeError:
                 #  try to use the pvconst arg or create one if none
                 if not pvconst:


### PR DESCRIPTION
* fixes #82 
* check for pvmodule object looks for pvconstants object, but the attribute is `pvconst` not `pvcons` so this fails, and prevents user from specifying a module