### PR TITLE
add new announcements for v4.1

### DIFF
--- a/pvmismatch/docs/index.rst
+++ b/pvmismatch/docs/index.rst
@@ -11,11 +11,7 @@ Version: |version| (|release|)
 
 Announcements
 -------------
-Thanks to Bennet Meyers you should see huge memory and speed improvements since
-new cell, module and string objects are only created when they are needed to
-differentiate cells by irradiance or temperature. However this can lead to
-unexpected behavior when changing other cell properties without first making a
-copy of the original cell.
+Starting at Nepal Negroni, users will be able to configure number of bypass diodes in a module. This includes being able to model a PV module with just one bypass diode across all the cells and the effect of losing one or more bypass diodes on a PV Module. 
 
 
 Contents:


### PR DESCRIPTION
@chetan201 it seems that changes were made directly to the generated docs, which were lost when the docs were regenerated. Specifically, the announcement was updated:

>Starting at Nepal Negroni, users will be able to configure number of bypass diodes in a module. This includes being able to model a PV module with just one bypass diode across all the cells and the effect of losing one or more bypass diodes on a PV Module. 

**Please note**: to make changes to the docs, the corresponding `.rst` file should be edited. Changes should _not_ be made directly to the generated docs, as these are auto-generated by sphinx, and should not be edited. For more info, please the [Documentation Content section of the wiki](../wiki/Documentation#content) - I'm sorry if this wasn't clear previously