### PR TITLE
[ENH] Add cache/memoization to PVcell properties (#121)

### DIFF
--- a/pvmismatch/pvmismatch_lib/pvcell.py
+++ b/pvmismatch/pvmismatch_lib/pvcell.py
@@ -12,6 +12,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 from scipy.optimize import newton
 import functools
+import copy
 
 # Defaults
 RS = 0.004267236774264931  # [ohm] series resistance
@@ -98,7 +99,8 @@ class PVcell(object):
         self.Pcell = None  #: cell power on IV curve [W]
         self.VocSTC = self._VocSTC()  #: estimated Voc at STC [V]
         # set calculation flag
-        self._calc_now = True  # overwrites the class attribute
+        super(PVcell, self).__setattr__('_calc_now', True)
+        #self._calc_now = True  # overwrites the class attribute
 
     def __str__(self):
         fmt = '<PVcell(Ee=%g[suns], Tcell=%g[K], Isc=%g[A], Voc=%g[V])>'
@@ -119,6 +121,11 @@ class PVcell(object):
         if self._calc_now:
             Icell, Vcell, Pcell = self.calcCell()
             self.__dict__.update(Icell=Icell, Vcell=Vcell, Pcell=Pcell)
+
+    def clone(self):
+        cloned = copy.copy(self)
+        super(PVcell, cloned).__setattr__('_cache', self._cache.copy())
+        return cloned
 
     def update(self, **kwargs):
         """

--- a/pvmismatch/pvmismatch_lib/pvcell.py
+++ b/pvmismatch/pvmismatch_lib/pvcell.py
@@ -11,6 +11,7 @@ from pvmismatch.pvmismatch_lib.pvconstants import PVconstants
 import numpy as np
 from matplotlib import pyplot as plt
 from scipy.optimize import newton
+import functools
 
 # Defaults
 RS = 0.004267236774264931  # [ohm] series resistance
@@ -29,13 +30,22 @@ EPS = np.finfo(np.float64).eps
 
 
 def cached(f):
+    """
+    Memoize an object's method using the _cache dictionary on the object.
+    """
+    @functools.wraps(f)
     def wrapper(self):
-        key = f.__name__
+        # note:  we use self.__wrapped__ instead of just using f directly
+        # so that we can spy on the original function in the test suite.
+        key = wrapper.__wrapped__.__name__
         if key in self._cache:
             return self._cache[key]
-        value = f(self)
+        value = wrapper.__wrapped__(self)
         self._cache[key] = value
         return value
+    # store the original function to be accessible by the test suite.
+    # functools.wraps already sets this in python 3.2+, but for older versions:
+    wrapper.__wrapped__ = f
     return wrapper
 
 

--- a/pvmismatch/pvmismatch_lib/pvcell.py
+++ b/pvmismatch/pvmismatch_lib/pvcell.py
@@ -123,6 +123,9 @@ class PVcell(object):
             self.__dict__.update(Icell=Icell, Vcell=Vcell, Pcell=Pcell)
 
     def clone(self):
+        """
+        Return a copy of this object with the same pvconst.
+        """
         cloned = copy.copy(self)
         super(PVcell, cloned).__setattr__('_cache', self._cache.copy())
         return cloned

--- a/pvmismatch/pvmismatch_lib/pvcell.py
+++ b/pvmismatch/pvmismatch_lib/pvcell.py
@@ -61,12 +61,13 @@ class PVcell(object):
     """
 
     _calc_now = False  #: if True ``calcCells()`` is called in ``__setattr__``
-    _cache = {}
 
     def __init__(self, Rs=RS, Rsh=RSH, Isat1_T0=ISAT1_T0, Isat2_T0=ISAT2_T0,
                  Isc0_T0=ISC0_T0, aRBD=ARBD, bRBD=BRBD, VRBD=VRBD_,
                  nRBD=NRBD, Eg=EG, alpha_Isc=ALPHA_ISC,
                  Tcell=TCELL, Ee=1., pvconst=PVconstants()):
+        # set up property cache
+        self._cache = {}
         # user inputs
         self.Rs = Rs  #: [ohm] series resistance
         self.Rsh = Rsh  #: [ohm] shunt resistance

--- a/pvmismatch/pvmismatch_lib/pvcell.py
+++ b/pvmismatch/pvmismatch_lib/pvcell.py
@@ -100,7 +100,7 @@ class PVcell(object):
         self.VocSTC = self._VocSTC()  #: estimated Voc at STC [V]
         # set calculation flag
         super(PVcell, self).__setattr__('_calc_now', True)
-        #self._calc_now = True  # overwrites the class attribute
+        self._calc_now = True  # overwrites the class attribute
 
     def __str__(self):
         fmt = '<PVcell(Ee=%g[suns], Tcell=%g[K], Isc=%g[A], Voc=%g[V])>'

--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -8,7 +8,6 @@ from past.builtins import xrange, range
 from builtins import zip
 from six import itervalues
 import numpy as np
-from copy import copy
 from matplotlib import pyplot as plt
 # use absolute imports instead of relative, so modules are portable
 from pvmismatch.pvmismatch_lib.pvconstants import PVconstants, get_series_cells
@@ -312,7 +311,7 @@ class PVmodule(object):
                 for pvc in pvcell_set:
                     pvc.Ee = Ee
             elif np.size(Ee) == self.numberCells:
-                self.pvcells = copy(self.pvcells)  # copy list first
+                self.pvcells = [cell.clone() for cell in self.pvcells]  # copy list first
                 for cell_idx, Ee_idx in enumerate(Ee):
                     self.pvcells[cell_idx] = self.pvcells[cell_idx].clone()
                     self.pvcells[cell_idx].Ee = Ee_idx
@@ -320,7 +319,7 @@ class PVmodule(object):
                 raise Exception("Input irradiance value (Ee) for each cell!")
         else:
             Ncells = np.size(cells)
-            self.pvcells = copy(self.pvcells)  # copy list first
+            self.pvcells = [cell.clone() for cell in self.pvcells]  # copy list first
             if np.isscalar(Ee):
                 cells_to_update = [self.pvcells[i] for i in cells]
                 old_pvcells = dict.fromkeys(cells_to_update)
@@ -384,7 +383,7 @@ class PVmodule(object):
                 for pvc in pvcell_set:
                     pvc.Tcell = Tc
             elif np.size(Tc) == self.numberCells:
-                self.pvcells = copy(self.pvcells)  # copy list first
+                self.pvcells = [cell.clone() for cell in self.pvcells]  # copy list first
                 for cell_idx, Tc_idx in enumerate(Tc):
                     self.pvcells[cell_idx] = self.pvcells[cell_idx].clone()
                     self.pvcells[cell_idx].Tcell = Tc_idx
@@ -392,7 +391,7 @@ class PVmodule(object):
                 raise Exception("Input temperature value (Tc) for each cell!")
         else:
             Ncells = np.size(cells)
-            self.pvcells = copy(self.pvcells)  # copy list first
+            self.pvcells = [cell.clone() for cell in self.pvcells]  # copy list first
             if np.isscalar(Tc):
                 cells_to_update = [self.pvcells[i] for i in cells]
                 old_pvcells = dict.fromkeys(cells_to_update)

--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -303,7 +303,7 @@ class PVmodule(object):
                 old_pvcells = dict.fromkeys(self.pvcells)  # same as set(pvcells)
                 for cell_id, pvcell in enumerate(self.pvcells):
                     if old_pvcells[pvcell] is None:
-                        new_pvcells[cell_id] = copy(pvcell)
+                        new_pvcells[cell_id] = pvcell.clone()
                         old_pvcells[pvcell] = new_pvcells[cell_id]
                     else:
                         new_pvcells[cell_id] = old_pvcells[pvcell]
@@ -314,7 +314,7 @@ class PVmodule(object):
             elif np.size(Ee) == self.numberCells:
                 self.pvcells = copy(self.pvcells)  # copy list first
                 for cell_idx, Ee_idx in enumerate(Ee):
-                    self.pvcells[cell_idx] = copy(self.pvcells[cell_idx])
+                    self.pvcells[cell_idx] = self.pvcells[cell_idx].clone()
                     self.pvcells[cell_idx].Ee = Ee_idx
             else:
                 raise Exception("Input irradiance value (Ee) for each cell!")
@@ -326,7 +326,7 @@ class PVmodule(object):
                 old_pvcells = dict.fromkeys(cells_to_update)
                 for cell_id, pvcell in zip(cells, cells_to_update):
                     if old_pvcells[pvcell] is None:
-                        self.pvcells[cell_id] = copy(pvcell)
+                        self.pvcells[cell_id] = pvcell.clone()
                         self.pvcells[cell_id].Ee = Ee
                         old_pvcells[pvcell] = self.pvcells[cell_id]
                     else:
@@ -344,7 +344,7 @@ class PVmodule(object):
                     old_pvcells = dict.fromkeys(cells_to_update)
                     for cell_id, pvcell in zip(cells_subset, cells_to_update):
                         if old_pvcells[pvcell] is None:
-                            self.pvcells[cell_id] = copy(pvcell)
+                            self.pvcells[cell_id] = pvcell.clone()
                             self.pvcells[cell_id].Ee = a_Ee
                             old_pvcells[pvcell] = self.pvcells[cell_id]
                         else:
@@ -375,7 +375,7 @@ class PVmodule(object):
                 old_pvcells = dict.fromkeys(self.pvcells)  # same as set(pvcells)
                 for cell_id, pvcell in enumerate(self.pvcells):
                     if old_pvcells[pvcell] is None:
-                        new_pvcells[cell_id] = copy(pvcell)
+                        new_pvcells[cell_id] = pvcell.clone()
                         old_pvcells[pvcell] = new_pvcells[cell_id]
                     else:
                         new_pvcells[cell_id] = old_pvcells[pvcell]
@@ -386,7 +386,7 @@ class PVmodule(object):
             elif np.size(Tc) == self.numberCells:
                 self.pvcells = copy(self.pvcells)  # copy list first
                 for cell_idx, Tc_idx in enumerate(Tc):
-                    self.pvcells[cell_idx] = copy(self.pvcells[cell_idx])
+                    self.pvcells[cell_idx] = self.pvcells[cell_idx].clone()
                     self.pvcells[cell_idx].Tcell = Tc_idx
             else:
                 raise Exception("Input temperature value (Tc) for each cell!")
@@ -398,7 +398,7 @@ class PVmodule(object):
                 old_pvcells = dict.fromkeys(cells_to_update)
                 for cell_id, pvcell in zip(cells, cells_to_update):
                     if old_pvcells[pvcell] is None:
-                        self.pvcells[cell_id] = copy(pvcell)
+                        self.pvcells[cell_id] = pvcell.clone()
                         self.pvcells[cell_id].Tcell = Tc
                         old_pvcells[pvcell] = self.pvcells[cell_id]
                     else:
@@ -416,7 +416,7 @@ class PVmodule(object):
                     old_pvcells = dict.fromkeys(cells_to_update)
                     for cell_id, pvcell in zip(cells_subset, cells_to_update):
                         if old_pvcells[pvcell] is None:
-                            self.pvcells[cell_id] = copy(pvcell)
+                            self.pvcells[cell_id] = pvcell.clone()
                             self.pvcells[cell_id].Tcell = a_Tc
                             old_pvcells[pvcell] = self.pvcells[cell_id]
                         else:

--- a/pvmismatch/pvmismatch_lib/pvmodule.py
+++ b/pvmismatch/pvmismatch_lib/pvmodule.py
@@ -8,6 +8,7 @@ from past.builtins import xrange, range
 from builtins import zip
 from six import itervalues
 import numpy as np
+from copy import copy
 from matplotlib import pyplot as plt
 # use absolute imports instead of relative, so modules are portable
 from pvmismatch.pvmismatch_lib.pvconstants import PVconstants, get_series_cells
@@ -311,7 +312,7 @@ class PVmodule(object):
                 for pvc in pvcell_set:
                     pvc.Ee = Ee
             elif np.size(Ee) == self.numberCells:
-                self.pvcells = [cell.clone() for cell in self.pvcells]  # copy list first
+                self.pvcells = copy(self.pvcells)  # copy list first
                 for cell_idx, Ee_idx in enumerate(Ee):
                     self.pvcells[cell_idx] = self.pvcells[cell_idx].clone()
                     self.pvcells[cell_idx].Ee = Ee_idx
@@ -319,7 +320,7 @@ class PVmodule(object):
                 raise Exception("Input irradiance value (Ee) for each cell!")
         else:
             Ncells = np.size(cells)
-            self.pvcells = [cell.clone() for cell in self.pvcells]  # copy list first
+            self.pvcells = copy(self.pvcells)  # copy list first
             if np.isscalar(Ee):
                 cells_to_update = [self.pvcells[i] for i in cells]
                 old_pvcells = dict.fromkeys(cells_to_update)
@@ -383,7 +384,7 @@ class PVmodule(object):
                 for pvc in pvcell_set:
                     pvc.Tcell = Tc
             elif np.size(Tc) == self.numberCells:
-                self.pvcells = [cell.clone() for cell in self.pvcells]  # copy list first
+                self.pvcells = copy(self.pvcells)  # copy list first
                 for cell_idx, Tc_idx in enumerate(Tc):
                     self.pvcells[cell_idx] = self.pvcells[cell_idx].clone()
                     self.pvcells[cell_idx].Tcell = Tc_idx
@@ -391,7 +392,7 @@ class PVmodule(object):
                 raise Exception("Input temperature value (Tc) for each cell!")
         else:
             Ncells = np.size(cells)
-            self.pvcells = [cell.clone() for cell in self.pvcells]  # copy list first
+            self.pvcells = copy(self.pvcells)  # copy list first
             if np.isscalar(Tc):
                 cells_to_update = [self.pvcells[i] for i in cells]
                 old_pvcells = dict.fromkeys(cells_to_update)

--- a/pvmismatch/tests/test_pvcell.py
+++ b/pvmismatch/tests/test_pvcell.py
@@ -128,6 +128,21 @@ def test_cache(mocker):
         spy.assert_called_once()
 
 
+def test_clone():
+    """
+    Test that the clone method returns an independent object.
+    """
+    # test independence
+    pvc1 = PVcell()
+    pvc2 = pvc1.clone()
+    pvc1.Ee = 0.5
+    assert pvc2.Ee == 1.0
+
+    # test returns identical
+    pvc3 = pvc1.clone()
+    assert np.allclose(pvc1.calcCell(), pvc3.calcCell())
+
+
 if __name__ == "__main__":
     i, v = test_calc_series()
     iv_calc = np.concatenate([[i], [v]], axis=0).T

--- a/pvmismatch/tests/test_pvcell.py
+++ b/pvmismatch/tests/test_pvcell.py
@@ -107,6 +107,27 @@ def test_update():
     assert pvc._calc_now
 
 
+def test_cache(mocker):
+    """
+    Test that the cache mechanism actually works and doesn't calculate the same
+    thing more than once.
+    """
+    pvc = PVcell()
+    attrs = ['Vt', 'Isc', 'Aph', 'Isat1', 'Isat2', 'Isc0', 'Voc', 'Igen']
+    # it's a little tricky to get ahold of the underlying function for the
+    # properties -- by accessing the property through the class rather than
+    # the instance, we get access to the `fget` object, which is the wrapper
+    # function.  And the @cached decorator stores the underlying function
+    # in the __wrapped__ attribute on the wrapper.
+    spies = [
+        mocker.spy(getattr(PVcell, attr).fget, "__wrapped__")
+        for attr in attrs
+    ]
+    pvc.Ee = 0.5
+    for spy in spies:
+        spy.assert_called_once()
+
+
 if __name__ == "__main__":
     i, v = test_calc_series()
     iv_calc = np.concatenate([[i], [v]], axis=0).T

--- a/pvmismatch/tests/test_pvcell.py
+++ b/pvmismatch/tests/test_pvcell.py
@@ -141,6 +141,7 @@ def test_clone():
     # test returns identical
     pvc3 = pvc1.clone()
     assert np.allclose(pvc1.calcCell(), pvc3.calcCell())
+    assert pvc1.pvconst is pvc3.pvconst
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ INSTALL_REQUIRES = [
 ]
 
 TESTS_REQUIRES = [
-    'nose>=1.3.7', 'pytest>=3.2.1', 'sympy>=1.1.1', 'pvlib>=0.5.1'
+    'nose>=1.3.7', 'pytest>=3.2.1', 'sympy>=1.1.1', 'pvlib>=0.5.1',
+    'pytest-mock'
 ]
 
 CLASSIFIERS = [


### PR DESCRIPTION
- [x] closes #121 

This PR adds a caching mechanism to the PVcell class such that successive calls to a property reuse the previously calculated value instead of recalculating it and causing a cascade of other property recalculations as well. 

There are two things I want to highlight:

1) The PR in its current state does fail several tests in the `test_setsuns` suite due to PVmodule's use of `copy.copy()` on PVcell objects:  because it is a shallow copy, the cache dictionary is shared by all instances, which is of course not desirable.  By replacing all of the `copy` calls with `deepcopy` I am able to get the tests to pass, but that approach seems rather heavy-handed and I wonder if others see a better approach. 
2) As with all caching, invalidation is the hard part.  I'm not familiar enough with the core internals of pvmismatch (really I have only read through the PVcell source code in any depth) to be confident that the cache is cleared in all cases that it should be, although the fact that the test suite passes is encouraging. 

Here is a timing comparison -- nothing rigorous, just `pytest --durations=0 pvmismatch\tests`.  Note that these timings were performed using the `deepcopy` modification described above, which is not currently committed in this PR.

| test                                                             | master| PR    |
|------------------------------------------------------------------|-------|-------|
| test_pvmodule.py::test_calc_tct_mod                              | 3.55s | 0.44s |
| test_setsuns.py::test_gh34_35                                    | 3.42s | 0.46s |
| test_settemps.py::test_settemp                                   | 3.13s | 0.49s |
| test_setsuns.py::test_basic                                      | 1.66s | 0.77s |
| test_pvconstants.py::test_minimum_current_close_to_max_voc_gh110 | 1.48s | 0.76s |
| test_setsuns.py::test_set_str_2                                  | 0.98s | 0.13s |
| test_setsuns.py::test_set_str_1                                  | 0.84s | 0.14s |
| test_setsuns.py::test_set_mod_1                                  | 0.83s | 0.08s |
| test_setsuns.py::test_set_mod_2                                  | 0.80s | 0.09s |
| test_setsuns.py::test_dictionary                                 | 0.78s | 0.07s |
| test_pvmodule.py::test_calc_pct_bridges                          | 0.67s | 0.21s |
| test_pvmodule.py::test_calc_pct_mod                              | 0.49s | 0.15s |
| test_pvsystem.py::test_pvsystem_with_pvstrs_obj                  | 0.46s | 0.04s |
| test_pvsystem.py::test_pvsystem_with_no_pvstrs                   | 0.44s | 0.05s |
| test_pvsystem.py::test_pvsystem_with_pvstrs_list                 | 0.42s | 0.05s |
| test_pvmodule.py::test_bypass_diode_configurations               | 0.05s | 0.04s |
| test_pvstring.py::test_pvstring_with_no_pvmods                   | 0.01s | 0.01s |
| test_pvstring.py::test_pvstring_with_pvmods_obj                  | 0.01s | 0.01s |
| test_pvstring.py::test_pvstring_with_pvmods_list                 | 0.01s | 0.01s |
| test_pvcell.py::test_calc_series                                 | 0.01s | 0.01s |
| test_pvmodule.py::test_pvmodule_with_pvcells_obj                 | 0.01s | 0.01s |
| test_pvmodule.py::test_pvmodule_with_no_pvcells                  | 0.01s | 0.01s |
| test_pvmodule.py::test_pvmodule_with_pvcells_list                | 0.01s | 0.01s |
| test_pvmodule.py::test_calc_mod                                  | 0.01s | 0.01s |
| test_settemps.py::test_settemp_cell                              | 0.01s | 0.01s |
